### PR TITLE
Remove port from server address

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "watch": "rm -rf public && brunch watch",
     "build": "rm -rf public && brunch build --production",
-    "start": "wp server --host=0.0.0.0:3000 --docroot=../../../",
+    "start": "wp server --host=0.0.0.0 --docroot=../../../",
     "git-update": "git pull origin develop && git submodule update --init && git submodule update --remote --merge",
     "deploy": "npm run git-update && npm i && npm run build"
   },


### PR DESCRIPTION
* Server port would need to be defined by another flag rather than be
appended to the end of the server address `0.0.0.0`. For WP projects
best to use the default port which is `8080` and use `3000` for rails
projects