### PR TITLE
Events listing

### DIFF
--- a/app/stylesheets/templates/_listing.scss
+++ b/app/stylesheets/templates/_listing.scss
@@ -1,4 +1,8 @@
 .blog {
+  margin: 0 auto;
+  max-width: 1100px;
+  padding: 0 40px;
+
   &__container {
     display: flex;
     flex-direction: row;
@@ -11,8 +15,8 @@
   display: flex;
   flex-direction: column;
   height: 450px;
-  margin: 20px 40px 0 0;
-  width: 33%;
+  margin-top: 20px;
+  max-width: 33%;
 
   &__link {
     height: 100%;
@@ -63,4 +67,20 @@
 
 .block:nth-child(3n+3) {
   margin-right: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .blog {
+    padding: 0 20px
+  }
+
+  .block {
+    max-width: 48%;
+  }
+}
+
+@media only screen and (max-width: 550px) {
+  .block {
+    max-width: 100%;
+  }
 }

--- a/archive-events.php
+++ b/archive-events.php
@@ -1,4 +1,7 @@
 <?php
+/**
+* Template Name: Events Listing page
+*/
 get_header();
 
 $events = new Query('events');
@@ -8,7 +11,9 @@ $query_args = [
 $results = $events->query($query_args);
 ?>
 
-<section class="container">
+<h2 class="content-title"><?php the_title(); ?></h2>
+<section class="blog">
+  <ul class="blog__container grid">
 
   <?php
   if($results->have_posts()): while($results->have_posts()): $results->the_post();
@@ -16,10 +21,24 @@ $results = $events->query($query_args);
     ?>
 
 
-    <p><?php echo $event_fields->field('quote'); ?></p>
+    <li class="block grid__col">
+      <a class="block__link" href="<?php the_permalink(); ?>">
+
+        <?php $post_image = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'large'); ?>
+
+        <div class="block__img" style="background-image: url('<?php echo $post_image[0]; ?>')"></div>
+        <div class="block__info">
+          <h3 class="block__info--title"><?php the_title(); ?></h3>
+          <p class="block__info--excerpt"><?php the_excerpt(); ?></p>
+          <p class="block__info--read-more">Read More</p>
+        </div>
+
+      </a>
+    </li>
 
 
   <?php endwhile; endif; ?>
+</ul>
 
 </section>
 

--- a/archive-events.php
+++ b/archive-events.php
@@ -20,7 +20,6 @@ $results = $events->query($query_args);
     $event_fields = new CMB2Fields(get_the_ID());
     ?>
 
-
     <li class="block grid__col">
       <a class="block__link" href="<?php the_permalink(); ?>">
 
@@ -35,7 +34,6 @@ $results = $events->query($query_args);
 
       </a>
     </li>
-
 
   <?php endwhile; endif; ?>
 </ul>

--- a/includes/class.custom-post-types.php
+++ b/includes/class.custom-post-types.php
@@ -14,7 +14,7 @@ Class CustomPostTypes {
       ],
       'public' => true,
       'menu_position' => '28',
-      'menu_icon' => 'dashicons-editor-quote',
+      'menu_icon' => 'dashicons-calendar-alt',
       'capability_type' => 'post',
       'has_archive' => true,
       'supports' => [

--- a/index.php
+++ b/index.php
@@ -10,10 +10,9 @@ foreach($post_category as $category):
 endforeach;
 
 get_header();
-get_template_part('templates/header-quote', 'tpl');
 ?>
 
-<h2 class="content-title">Blog</h2>
+<h2 class="content-title"><?php the_title(); ?></h2>
 
 <section class="blog">
 
@@ -27,7 +26,7 @@ get_template_part('templates/header-quote', 'tpl');
 
   	<!-- the loop -->
   	<?php while ( $wpb_all_query->have_posts() ) : $wpb_all_query->the_post(); ?>
-  		<li class="block grid__col col-4">
+  		<li class="block grid__col">
         <a class="block__link" href="<?php the_permalink(); ?>">
 
           <?php $post_image = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'large'); ?>


### PR DESCRIPTION
- fix listing grid layout
- stack blocks responsively

Events
![screen shot 2017-01-21 at 18 26 59](https://cloud.githubusercontent.com/assets/16079796/22176650/397f0b26-e007-11e6-9c1d-d2482ae62172.png)

Events iPad:
![screen shot 2017-01-21 at 18 26 46](https://cloud.githubusercontent.com/assets/16079796/22176652/3e9365ee-e007-11e6-9eba-cdb70dc62835.png)

Events iPhone 6
![screen shot 2017-01-21 at 18 26 28](https://cloud.githubusercontent.com/assets/16079796/22176653/45832ac4-e007-11e6-8e80-d7b3fc1b860e.png)

Blog 
![screen shot 2017-01-21 at 18 25 14](https://cloud.githubusercontent.com/assets/16079796/22176658/4dacb814-e007-11e6-8fd3-a7f5e71c3a4d.png)

Blog iPad
![screen shot 2017-01-21 at 18 25 39](https://cloud.githubusercontent.com/assets/16079796/22176661/57b50ce4-e007-11e6-9806-3b6dd0d05619.png)

iPhone 6
![screen shot 2017-01-21 at 18 26 10](https://cloud.githubusercontent.com/assets/16079796/22176663/5d4289b6-e007-11e6-9bf8-4e22ca6252bf.png)
