### PR TITLE
Hooked up Our Vision/branches sections to backend

### DIFF
--- a/about-page.php
+++ b/about-page.php
@@ -5,6 +5,7 @@
 get_header();
 
 $page = new CMB2Fields(get_the_ID());
+$about_us = new CMB2Fields(get_the_ID());
 
 $post_image = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'large');
 ?>
@@ -16,7 +17,18 @@ $post_image = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'lar
   </div>
 </section>
 
+<section class="two-block">
+  <div class="two-block__section">
+    <h3 class="two-block__section--title">Our Vision</h3>
+    <p class="two-block__section--text"><?php echo $about_us->format_content($about_us->field('our_vision_text')); ?></p>
+  </div>
+  <div class="two-block__section">
+    <h3 class="two-block__section--title">Branches</h3>
+  <p class="two-block__section--text"><?php echo $about_us->format_content($about_us->field('our_branches_text')); ?></p>
+  </div>
+</section>
+
+
 <?php
-get_template_part('templates/two-block', 'tpl');
 get_template_part('templates/our-team', 'tpl');
 get_footer();

--- a/includes/custom-metaboxes/cmb2-about-fields.php
+++ b/includes/custom-metaboxes/cmb2-about-fields.php
@@ -1,0 +1,22 @@
+<?php
+
+$about_us = new_cmb2_box([
+  'id' => 'about_us',
+  'title' => __('Our Vision & Our Branches', 'imi'),
+  'object_types' => ['page'],
+  'context' => 'normal',
+  'priority' => 'high',
+  'show_names' => true
+]);
+
+$about_us->add_field([
+  'desc' => __('Enter text to be displayed in Our Vision section'),
+  'id' => $prefix . 'our_vision_text',
+  'type' => 'wysiwyg'
+]);
+
+$about_us->add_field([
+  'desc' => __('Enter text to be displayed in Our Branches section'),
+  'id' => $prefix . 'our_branches_text',
+  'type' => 'wysiwyg'
+]);


### PR DESCRIPTION
- There is a bug where this ends up being a `<p>` within a `<p>` and therefore affects the styling of this text. Must look into this at some point.

![screen shot 2017-01-22 at 20 50 46](https://cloud.githubusercontent.com/assets/16079796/22185825/aad23270-e0e4-11e6-8efc-2b8b48ff7b20.png)
